### PR TITLE
use pixi for RTD env

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 .git_archival.txt  export-subst
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ data/*
 tmp*
 
 .vscode*
+# pixi environments
+.pixi/*
+!.pixi/config.toml
+pixi.lock

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,18 +6,19 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    # just so RTD stops complaining
+    python: "latest"
   jobs:
     create_environment:
-      - asdf plugin add uv
-      - asdf install uv latest
-      - asdf global uv latest
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --only-group
-        docs
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv pip install .
-        --no-deps
+      - asdf plugin add pixi
+      - asdf install pixi latest
+      - asdf global pixi latest
     install:
-      - "true"
+      - pixi install --environment docs
+    build:
+      html:
+        - pixi run -e docs sphinx-build -n -T -b html docs
+          $READTHEDOCS_OUTPUT/html
 
 sphinx:
   configuration: docs/conf.py

--- a/environment.yml
+++ b/environment.yml
@@ -33,10 +33,6 @@ dependencies:
   - cartopy
   - ipyleaflet
   - ipython>=8.13.0
-  # test
-  - pytest>=6
-  - pytest-cov>=3
-  - deepdiff
   # docs
   - sphinx>=7.0
   - myst-parser>=0.13
@@ -50,6 +46,9 @@ dependencies:
   - sphinx-autoapi
   - sphinx-design
   # dev
+  - pytest>=6
+  - pytest-cov>=3
+  - deepdiff
   - jupyterlab
   # below packages need to be installed with pip
   # - pip

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,8 +52,8 @@ def tests(session: nox.Session) -> None:
     Run the unit and regular tests.
     """
     session.conda_install("pygmt", "geopandas")
-    test_deps = nox.project.dependency_groups(PROJECT, "test")
-    session.install("-e.", *test_deps)
+    deps = nox.project.dependency_groups(PROJECT, "dev")
+    session.install("-e.", *deps)
     session.run(
         "pytest",
         "--cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,14 +60,10 @@ interactive = [
     "ipyleaflet",
     "ipython>=8.13.0",
 ]
-test = [
-  {include-group = "interactive"},
-  "pytest >=6",
-  "pytest-cov >=3",
-  "deepdiff",
-]
 dev = [
-    {include-group = "test"},
+    "pytest >=6",
+    "pytest-cov >=3",
+    "deepdiff",
     "jupyterlab",
 ]
 docs = [
@@ -86,7 +82,6 @@ docs = [
 
 all = [
   {include-group = "interactive"},
-  {include-group = "test"},
   {include-group = "dev"},
   {include-group = "docs"},
 ]
@@ -221,3 +216,65 @@ messages_control.disable = [
 
 [tool.codespell]
 ignore-words-list = ["word_to_ignore"]
+
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
+
+[tool.pixi.pypi-dependencies]
+polartoolkit = { path = ".", editable = true }
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+all = { features = ["all"], solve-group = "default" }
+dev = { features = ["dev"], solve-group = "default" }
+docs = { features = ["docs"], solve-group = "default" }
+interactive = { features = ["interactive"], solve-group = "default" }
+
+# NOTE: pixi will match project.dependencies versions above but get them from conda-forge
+# If a package is listed in project.dependencies but not repeated here, it is installed from pypi
+[tool.pixi.dependencies]
+numpy = ">=1.25"
+pandas = ">=2.0"
+xarray = ">=2023.4"
+scipy = ">=1.11"
+verde = "*"
+pooch = "*"
+rioxarray = "*"
+tqdm = "*"
+pygmt = ">=0.10"
+harmonica = ">=0.6"
+deprecation = "*"
+openpyxl = "*"
+pyproj = "*"
+geopandas = ">=1.0"
+pyogrio = "*"
+zarr = ">=3.0"
+python-dotenv = "*"
+requests = "*"
+earthaccess = "*"
+xrft = "*"
+
+[tool.pixi.feature.interactive.dependencies]
+geoviews = "*"
+cartopy = "*"
+ipyleaflet = "*"
+ipython = ">=8.13"
+
+[tool.pixi.feature.dev.dependencies]
+pytest = ">=6"
+pytest-cov = ">=3"
+deepdiff = "*"
+jupyterlab = "*"
+
+[tool.pixi.feature.docs.dependencies]
+sphinx = ">=7.0"
+myst-parser = ">=0.13"
+sphinx-copybutton = "*"
+sphinx-autodoc-typehints = "*"
+sphinx-book-theme = ">=0.3"
+nbsphinx = "*"
+ipykernel = "*"
+nbconvert = "*"
+sphinxcontrib-bibtex = "*"
+sphinx-design = "*"


### PR DESCRIPTION
RTD wasn't showing the API, since it was trying to install polartoolkit and it's dependencies with `uv`. This doesn't work for installing dependencies with `C` dependencies (`pygmt`), so the `uv` install failed. Options to fix this are to update `readthedocs.yaml` to use a conda `environment.yml` file for creating the RTD environment, or to use `pixi` instead of `uv`. These commits use `pixi`, which works, but it adds quite a bit of extra code, specifically in the `pyproject.toml` which seems unnecessarily complicated. To get this to work required lots of trial and error, with help from the below projects:
https://github.com/OceanParcels/Parcels/blob/v4-dev/.readthedocs.yaml
https://github.com/OceanParcels/Parcels/blob/v4-dev/pixi.toml
https://github.com/uw-cryo/coincident/blob/main/.readthedocs.yaml
https://github.com/uw-cryo/coincident/blob/main/pyproject.toml