### PR TITLE
Updates for latest PyGMT version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pooch
   - rioxarray
   - tqdm
-  - pygmt>=0.10.0
+  - pygmt>=0.18.0
   - harmonica>=0.6.0
   - deprecation
   - openpyxl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pooch",
     "rioxarray",
     "tqdm",
-    "pygmt>=0.10.0", # need parameter "log" for colorbar
+    "pygmt>=0.18.0", # need aliases for scale and deprecated parameters such as barwidth
     "harmonica>=0.6.0", # need load_oasis_montaj_grid function
     "deprecation",
     "openpyxl", # needed for fetch.ghf to read an excel file into pandas

--- a/src/polartoolkit/maps.py
+++ b/src/polartoolkit/maps.py
@@ -375,7 +375,7 @@ class Figure(pygmt.Figure):  # type: ignore[misc]
             MAP_ANNOT_MIN_SPACING="auto",
             MAP_FRAME_TYPE="inside",
             MAP_ANNOT_OBLIQUE="anywhere",
-            FONT_ANNOT_PRIMARY="8p,black,-=2p,white",
+            FONT_ANNOT_PRIMARY="8p,-=2p,white",
             MAP_GRID_PEN_PRIMARY="auto,gray",
             MAP_TICK_LENGTH_PRIMARY="auto",
             MAP_TICK_PEN_PRIMARY="auto,gray",

--- a/src/polartoolkit/maps.py
+++ b/src/polartoolkit/maps.py
@@ -1485,7 +1485,7 @@ class Figure(pygmt.Figure):  # type: ignore[misc]
                     cmap=cmap,
                     fill=kwargs.get("hist_fill"),
                     pen=kwargs.get("hist_pen", "default"),
-                    barwidth=kwargs.get("hist_barwidth"),
+                    bar_width=kwargs.get("hist_barwidth"),
                     center=kwargs.get("hist_center", False),
                     distribution=kwargs.get("hist_distribution", False),
                     cumulative=kwargs.get("hist_cumulative", False),

--- a/src/polartoolkit/profiles.py
+++ b/src/polartoolkit/profiles.py
@@ -990,7 +990,7 @@ def plot_profile(
                 fig.legend(
                     position=kwargs.get("data_legend_loc", "JBR+jBL+o0c"),
                     box=kwargs.get("data_legend_box", False),
-                    S=kwargs.get("data_legend_scale", 1),
+                    scale=kwargs.get("data_legend_scale", 1),
                 )
 
         if kwargs.get("data_line_cmap") is not None:
@@ -1150,7 +1150,7 @@ def plot_profile(
             fig.legend(
                 position=kwargs.get("layers_legend_loc", "JBR+jBL+o0c"),
                 box=kwargs.get("layers_legend_box", False),
-                S=kwargs.get("layers_legend_scale", 1),
+                scale=kwargs.get("layers_legend_scale", 1),
             )
 
     # plot 'A','B' locations
@@ -1585,7 +1585,7 @@ def plot_data(
             fig.legend(
                 position=kwargs.get("data_legend_loc", "JBR+jBL+o0c"),
                 box=kwargs.get("data_legend_box", False),
-                S=kwargs.get("data_legend_scale", 1),
+                scale=kwargs.get("data_legend_scale", 1),
             )
     if kwargs.get("data_line_cmap") is not None:
         fig.colorbar(


### PR DESCRIPTION
Update various pygmt parameter names and bump min pygmt version. Also fixes a warning emitted by GMT about invalid font used when trying to add a buffer/shadow around text.